### PR TITLE
Corrected Solution 2.6

### DIFF
--- a/src/text/appendices/c_2.md
+++ b/src/text/appendices/c_2.md
@@ -102,8 +102,8 @@ The set of ground instances of this clause is
 ```
 and the Herbrand base is
 ```Prolog
-{ likes(peter,peter),      likes(peter,maria),
-  likes(maria,peter),      likes(maria,maria),
+{ likes(peter,peter),      likes(maria,peter),
+  likes(peter,maria),      likes(maria,maria),
   student_of(peter,peter), student_of(peter,maria),
   student_of(maria,peter), student_of(maria,maria) }
 ```

--- a/src/text/appendices/c_2.md
+++ b/src/text/appendices/c_2.md
@@ -107,7 +107,7 @@ and the Herbrand base is
   student_of(peter,peter), student_of(peter,maria),
   student_of(maria,peter), student_of(maria,maria) }
 ```
-Only the left four ground atoms are relevant for determining whether an interpretation is a model. 9 out of 16 truth-value assignments to these ground atoms result in a model. Because of the 4 irrelevant ground atoms, this yields $9*2^4=144$ models. Notice that this is a rather large number of models for such a modest Herbrand universe, and such a simple clause! This illustrates that *less knowledge leads to more models*.
+Only the four ground atoms in the left column are relevant for determining whether an interpretation is a model. 9 out of 16 truth-value assignments to these ground atoms result in a model. Because of the 4 irrelevant ground atoms, this yields $9*2^4=144$ models. Notice that this is a rather large number of models for such a modest Herbrand universe, and such a simple clause! This illustrates that *less knowledge leads to more models*.
 
 +++
 


### PR DESCRIPTION
Reordered the Herbrand base to comply with the sentence "Only the left four ground atoms are relevant for determining whether an interpretation is a model"