### PR TITLE
Add PDF build instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ You can download a free PDF copy or view an online version.
 [![PDF](https://img.shields.io/badge/read-PDF-green.svg)](https://github.com/simply-logical/simply-logical/releases/download/v1.0/SL.pdf)  
 The PDF version of the original book is available as a [*GitHub release*](https://github.com/simply-logical/simply-logical/releases/tag/v1.0).
 
+If you want to build the PDF version yourself, you can install openjournals/inara locally or use Docker:
+```
+docker run --rm -v $PWD:/data -u $(id -u):$(id -g) --env JOURNAL=jose openjournals/inara:latest -o pdf paper/paper.md
+```
+
+Note: the Docker command might log a "Killed" message if your instance of Docker runs out of memory. You might need as much as 14 GB allocated to Docker for the book.
+
 ## Online version ##
 [![Online](https://img.shields.io/badge/read-online-green.svg)](https://book.simply-logical.space)  
 The online version of the book is hosted on [*GitHub Pages*](https://book.simply-logical.space).


### PR DESCRIPTION
I was trying to figure out how to build the PDF of the book using a few sources:
- https://github.com/simply-logical/simply-logical/blob/54d92fa72c2a1ae9e4a18962f4cdcb53225b4e0b/.github/workflows/build-jose.yml#L20-L24
- https://github.com/openjournals/openjournals-draft-action/blob/master/action.yml#L14-L22
- https://github.com/openjournals/inara#usage-via-docker

So I ended up with this command:
```
docker run --rm -v $PWD:/data -u $(id -u):$(id -g) --env JOURNAL=jose openjournals/inara:latest -o pdf paper/paper.md
```

At first the container is killed because it ran out of memory. I have set to 8 GB on my machine, which I thought was already a lot.
```
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
[INFO] Running filter /usr/local/share/openjournals/data/filters/parse-latex.lua
[INFO] Completed filter /usr/local/share/openjournals/data/filters/parse-latex.lua in 120 ms
[INFO] Running filter /usr/local/share/openjournals/data/filters/inline-cited-references.lua
[INFO] Loaded paper.bib from paper.bib
[INFO] Completed filter /usr/local/share/openjournals/data/filters/inline-cited-references.lua in 162 ms
[INFO] Running filter citeproc
[INFO] Loaded apa.csl from /usr/local/share/openjournals/apa.csl
[INFO] Completed filter citeproc in 332 ms
[INFO] Running filter /usr/local/share/openjournals/data/filters/normalize-metadata.lua
[INFO] Completed filter /usr/local/share/openjournals/data/filters/normalize-metadata.lua in 37 ms
[INFO] Running filter /usr/local/share/openjournals/data/filters/time.lua
[INFO] Completed filter /usr/local/share/openjournals/data/filters/time.lua in 18 ms
[INFO] Running filter /usr/local/share/openjournals/data/filters/normalize-author-names.lua
[INFO] Completed filter /usr/local/share/openjournals/data/filters/normalize-author-names.lua in 25 ms
[INFO] Running filter /usr/local/share/openjournals/data/filters/substitute-in-format.lua
[INFO] Completed filter /usr/local/share/openjournals/data/filters/substitute-in-format.lua in 22 ms
[INFO] Running filter /usr/local/share/openjournals/data/filters/add-images.lua
[INFO] Loaded jose/logo.png from /usr/local/share/openjournals/jose/logo.png
[INFO] Completed filter /usr/local/share/openjournals/data/filters/add-images.lua in 39 ms
[INFO] Running filter /usr/local/share/openjournals/data/filters/draft.lua
[INFO] Completed filter /usr/local/share/openjournals/data/filters/draft.lua in 17 ms
[INFO] Running filter /usr/local/share/openjournals/data/filters/self-citation.lua
Killed
```

I ended up having to set my system's Docker memory to 14 GB to finally build the whole thing, but it worked!

So I figured I'd contribute my findings to the README. 😄 