### PR TITLE
Upgrade Jupyter Book to v1

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -9,10 +9,10 @@ jobs:
       uses: actions/checkout@v2.3.1
       with:
         persist-credentials: false
-    - name: Set up Python 3.7 🐍
+    - name: Set up Python 3.9 🐍
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.9
     - name: Install dependencies 💾
       run: pip install -r requirements.txt
     - name: Build the book 🔧📖

--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ author: >
   <a href="mailto:Peter.Flach@bristol.ac.uk">Peter Flach</a> and
   <a href="mailto:K.Sokol@bristol.ac.uk">Kacper Sokol</a>,
   University of Bristol, United Kingdom
-copyright: '2015–2023'
+copyright: '2015–2024'
 logo: src/img/SL.svg
 
 exclude_patterns:
@@ -36,6 +36,11 @@ html:
     Commons Attribution-NonCommercial-ShareAlike 4.0 International Licence</a>.
     </p>
     <p>
+    <a href="https://github.com/simply-logical/simply-logical/blob/master/LICENCE"><img src="https://img.shields.io/badge/Licence-CC%20BY--NC--SA%204.0-lightgrey.svg" alt="Licence"></a>
+    &nbsp; &nbsp; &nbsp;
+    <a href="https://doi.org/10.5281/zenodo.1156977"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.1156977.svg" alt="DOI"></a>
+    </p>
+    <p>
     This book discusses methods to implement intelligent reasoning by means of
     Prolog programs.
     The book is written from the shared viewpoints of Computational Logic,
@@ -43,7 +48,8 @@ html:
     Intelligence, which seeks to implement aspects of intelligent behaviour on
     a computer.
     </p>
-  google_analytics_id: G-JFZBHCMB8V
+  analytics:
+    google_analytics_id: G-JFZBHCMB8V
   home_page_in_navbar: true
 
 parse:
@@ -68,6 +74,47 @@ sphinx:
     - sphinx_prolog.swish
     - sphinx_prolog.pprolog
   config:
+    html_theme_options:
+      repository_url: https://github.com/simply-logical/simply-logical
+      repository_branch: master
+      use_edit_page_button: true
+      use_repository_button: true
+      use_issues_button: true
+      home_page_in_toc: true
+      logo:
+        text: Simply Logical
+        image_light: src/img/SL.svg
+        image_dark: src/img/SL.svg
+      icon_links:
+        - name: Licence
+          url: https://github.com/simply-logical/simply-logical/blob/master/LICENCE
+          icon: https://img.shields.io/badge/Licence-CC%20BY--NC--SA%204.0-lightgrey.svg
+          type: url
+        # - name: DOI
+        #   url: https://doi.org/10.5281/zenodo.1156977
+        #   icon: https://zenodo.org/badge/DOI/10.5281/zenodo.1156977.svg
+        #   type: url
+      extra_footer: >
+        <p>
+        This work is licenced under the
+        <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative
+        Commons Attribution-NonCommercial-ShareAlike 4.0 International Licence</a>.
+        </p>
+        <p>
+        <a href="https://github.com/simply-logical/simply-logical/blob/master/LICENCE"><img src="https://img.shields.io/badge/Licence-CC%20BY--NC--SA%204.0-lightgrey.svg" alt="Licence"></a>
+        &nbsp; &nbsp; &nbsp;
+        <a href="https://doi.org/10.5281/zenodo.1156977"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.1156977.svg" alt="DOI"></a>
+        </p>
+        <p>
+        This book discusses methods to implement intelligent reasoning by means of
+        Prolog programs.
+        The book is written from the shared viewpoints of Computational Logic,
+        which aims at automating various kinds of reasoning, and Artificial
+        Intelligence, which seeks to implement aspects of intelligent behaviour on
+        a computer.
+        </p>
+      analytics:
+        google_analytics_id: G-JFZBHCMB8V
     html_extra_path:
       - README.md
       - LICENCE

--- a/_static/sl.css
+++ b/_static/sl.css
@@ -1,3 +1,7 @@
+:root {
+  color-scheme: light dark;
+}
+
 /*Highlight the hyper-link marker when hovering over the "title" of figures.*/
 main#main-content figure figcaption:hover a.headerlink {
   opacity: 0.5;
@@ -19,5 +23,5 @@ div.highlight-pProlog div.highlight pre {
   /* background-color: rgba(var(--pst-color-preformatted-background),1); */
   /* background-color: #FEF9EC; */
   /* background-color: #FFF0F5; */
-  background-color: #F0FFFF;
+  background-color: light-dark(#F0FFFF, #242525);
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
-jupyter-book==0.13.0
-sphinx-prolog>=0.5
+jupyter-book==1.0.3
+lxml[html_clean]==5.3.0
+# lxml==5.3.0
+# lxml_html_clean==0.4.1
+sphinx-prolog>=0.6


### PR DESCRIPTION
Issues:
- `extra_navbar` does not work anymore

The dependency chain for dark theme for reference:
- pydata/pydata-sphinx-theme v0.9.0 (Jun 8, 2022) added dark theme
- executablebooks/sphinx-book-theme v1.0.0 (2023-03-01) incorporated pydata/pydata-sphinx-theme v0.13
- jupyter-book/jupyter-book v0.15.0 (2023-03-07) incorporated executablebooks/sphinx-book-theme v1.0.0